### PR TITLE
Added documentation target for SPI documentation.

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [Table]


### PR DESCRIPTION
In your email, you mentioned that the package had DocC documentation. Adding this file, if you choose to, will cause the Swift Package Index to generate and host that DocC documentation on the web for you.

If you would prefer not to, please feel free to close this PR!